### PR TITLE
chore: update package.json for rollup build and add dist files

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,23 @@
     "name": "Dyniqo",
     "url": "https://github.com/Dyniqo"
   },
-  "description": "The TS-Flow Framework is a modular, extensible framework specifically designed to simplify workflow and task orchestration. It provides a powerful structure and intuitive API to handle simple to complex orchestrations, letting developers focus on business logic while ensuring efficient execution and scalability.",
+  "description": "",
   "main": "dist/ts-flow.cjs.js",
   "module": "dist/ts-flow.esm.js",
   "types": "dist/ts-flow.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/ts-flow.cjs.js",
+      "import": "./dist/ts-flow.esm.js",
+      "types": "./dist/ts-flow.d.ts"
+    },
+    "./iife": {
+      "import": "./dist/ts-flow.iife.min.js"
+    },
+    "./amd": {
+      "import": "./dist/ts-flow.amd.js"
+    }
+  },
   "type": "module",
   "scripts": {
     "build": "npm run clean && rollup -c",
@@ -18,7 +31,30 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage"
   },
-  "keywords": [],
+  "keywords": [
+    "workflow",
+    "task management",
+    "typescript",
+    "framework",
+    "orchestration",
+    "automation",
+    "modular",
+    "task orchestration",
+    "flow management",
+    "asynchronous",
+    "scalable",
+    "event-driven",
+    "cron scheduler",
+    "parallel tasks",
+    "retry policies",
+    "state management",
+    "hooks",
+    "error handling",
+    "es6 modules",
+    "iife",
+    "cjs",
+    "esm"
+  ],
   "homepage": "https://github.com/Dyniqo/ts-flow",
   "license": "MIT",
   "repository": {
@@ -41,6 +77,7 @@
     "@rollup/plugin-typescript": "^12.1.1",
     "@types/node": "^22.9.0",
     "@types/node-cron": "^3.0.11",
+    "rollup-plugin-terser": "^7.0.2",
     "typescript": "^5.7.2"
   }
 }

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -3,7 +3,7 @@ import commonjs from "@rollup/plugin-commonjs";
 import typescript from "@rollup/plugin-typescript";
 import dts from "rollup-plugin-dts";
 import json from "@rollup/plugin-json";
-// import { terser } from "rollup-plugin-terser";
+import { terser } from "rollup-plugin-terser";
 import del from "rollup-plugin-delete";
 const banner = `/*!
  * ts-flow
@@ -29,37 +29,41 @@ export default [
         sourcemap: true,
         banner
       },
-      //  {
-      //    file: "dist/ts-flow.amd.js",
-      //    format: "amd",
-      //    sourcemap: true,
-      //    banner
-      //  },
-      //  {
-      //    file: "dist/ts-flow-iife.js",
-      //    format: "iife",
-      //    name: "TSWebSocket",
-      //    sourcemap: true,
-      //    banner
-      //  },
-      //  {
-      //    file: "dist/ts-flow.iife.min.js",
-      //    format: "iife",
-      //    name: "TSWebSocket",
-      //    sourcemap: true,
-      //    plugins: [terser()],
-      //    banner
-      //  },
+      {
+        file: "dist/ts-flow.cjs.min.js",
+        format: "cjs",
+        sourcemap: true,
+        plugins: [terser()],
+        banner,
+      },
+      {
+        file: "dist/ts-flow.esm.min.js",
+        format: "esm",
+        sourcemap: true,
+        plugins: [terser()],
+        banner,
+      },
+      {
+        file: "dist/ts-flow.amd.js",
+        format: "amd",
+        sourcemap: true,
+        banner,
+      },
+      {
+        file: "dist/ts-flow-iife.js",
+        format: "iife",
+        sourcemap: true,
+        banner,
+      },
+      {
+        file: "dist/ts-flow.iife.min.js",
+        format: "iife",
+        sourcemap: true,
+        plugins: [terser()],
+        banner,
+      },
     ],
-    external: [
-      "inversify",
-      "jsonwebtoken",
-      "reflect-metadata",
-      "express",
-      "http",
-      "net",
-      "ws",
-    ],
+    external: [],
     plugins: [
       resolve(),
       commonjs(),


### PR DESCRIPTION
Updated the `package.json` to include necessary configurations for building the project with Rollup. The build process now correctly references the various output files (CJS, ESM, IIFE) in the `dist` folder. Additionally, added dist file paths and module types (CommonJS, ESM) for better compatibility with different environments. This update enhances the build pipeline and ensures the framework can be easily consumed via different module systems.

Changes include:
- Added Rollup build script configuration.
- Specified output files for CJS, ESM, and IIFE builds.
- Updated module types and file references in `package.json`.
